### PR TITLE
Add feature flag persistence with instant loading

### DIFF
--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -1,6 +1,5 @@
 "use client"
 
-import { useEffect, useState } from "react"
 import {
   Table,
   TableBody,
@@ -41,31 +40,10 @@ const tableData = [
 ]
 
 export default function Home() {
-  const [mounted, setMounted] = useState(false)
-  const { flags, isLoading, isError } = useFeatureFlags({
+  const { flags, isError } = useFeatureFlags({
     flags: ['showExtendedColumns']
   });
   const { toggleUser, hasFlag } = useUser();
-
-  useEffect(() => {
-    setMounted(true)
-  }, [])
-
-  if (!mounted) {
-    return (
-      <div className="min-h-screen bg-white flex items-center justify-center">
-        <p className="text-sm text-gray-600">Loading...</p>
-      </div>
-    );
-  }
-
-  if (isLoading) {
-    return (
-      <div className="min-h-screen bg-white flex items-center justify-center">
-        <p className="text-sm text-gray-600">Loading...</p>
-      </div>
-    );
-  }
 
   if (isError) {
     return (

--- a/apps/web/src/components/providers.tsx
+++ b/apps/web/src/components/providers.tsx
@@ -1,6 +1,6 @@
-"use client"
+"use client";
 
-import { createContext, useContext, useState } from "react";
+import React, { createContext, useContext, useState, ReactNode } from "react";
 import { FeatureFlagProvider } from "@feature-flag/gatekeeper";
 
 interface UserContextType {
@@ -12,16 +12,16 @@ interface UserContextType {
 const UserContext = createContext<UserContextType | undefined>(undefined);
 
 interface ProvidersProps {
-  children: React.ReactNode;
+  children: ReactNode;
 }
 
 export function Providers({ children }: ProvidersProps) {
   const [userId, setUserId] = useState("user-123");
-  
+
   const toggleUser = () => {
-    setUserId(prev => prev === "user-123" ? "user-122" : "user-123");
+    setUserId((prev) => (prev === "user-123" ? "user-122" : "user-123"));
   };
-  
+
   const hasFlag = userId === "user-122";
 
   return (
@@ -36,7 +36,7 @@ export function Providers({ children }: ProvidersProps) {
 export function useUser() {
   const context = useContext(UserContext);
   if (!context) {
-    throw new Error('useUser must be used within Providers');
+    throw new Error("useUser must be used within Providers");
   }
   return context;
 }

--- a/packages/gatekeeper/package-lock.json
+++ b/packages/gatekeeper/package-lock.json
@@ -9,7 +9,9 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
-        "@tanstack/react-query": "^5.83.0"
+        "@tanstack/query-async-storage-persister": "^5.83.1",
+        "@tanstack/react-query": "^5.83.0",
+        "@tanstack/react-query-persist-client": "^5.84.1"
       },
       "devDependencies": {
         "@types/react": "^18.0.0",
@@ -917,10 +919,34 @@
         "win32"
       ]
     },
+    "node_modules/@tanstack/query-async-storage-persister": {
+      "version": "5.83.1",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-async-storage-persister/-/query-async-storage-persister-5.83.1.tgz",
+      "integrity": "sha512-P3QzGBn9/nxaCst1hNYDQbbJDKFxTBsGTMjf0YtsKs7sSeNp7wVgUKjOVJpbvhdpFKHqTDYOdjOf2Qeb4bJ9tQ==",
+      "dependencies": {
+        "@tanstack/query-persist-client-core": "5.83.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
     "node_modules/@tanstack/query-core": {
       "version": "5.83.1",
       "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.83.1.tgz",
       "integrity": "sha512-OG69LQgT7jSp+5pPuCfzltq/+7l2xoweggjme9vlbCPa/d7D7zaqv5vN/S82SzSYZ4EDLTxNO1PWrv49RAS64Q==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/query-persist-client-core": {
+      "version": "5.83.1",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-persist-client-core/-/query-persist-client-core-5.83.1.tgz",
+      "integrity": "sha512-GPWt1tj8kmo3LA1WPpSmJA3JGCdQfaggb1LheFEfr3RuwbTchWd09xD/fZ40m9ai0pJupvyguLiWF8On8sQWPw==",
+      "dependencies": {
+        "@tanstack/query-core": "5.83.1"
+      },
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/tannerlinsley"
@@ -938,6 +964,22 @@
         "url": "https://github.com/sponsors/tannerlinsley"
       },
       "peerDependencies": {
+        "react": "^18 || ^19"
+      }
+    },
+    "node_modules/@tanstack/react-query-persist-client": {
+      "version": "5.84.1",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query-persist-client/-/react-query-persist-client-5.84.1.tgz",
+      "integrity": "sha512-Qpn2kg7eI+dI4AHeXmI0FYn1JVwluSESA3iJ+KJv9zZiluPhiFmzFT++j9QYwu/LHUwp4PmjqSPHkuBLiYkTRQ==",
+      "dependencies": {
+        "@tanstack/query-persist-client-core": "5.83.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "@tanstack/react-query": "^5.84.1",
         "react": "^18 || ^19"
       }
     },

--- a/packages/gatekeeper/package.json
+++ b/packages/gatekeeper/package.json
@@ -33,6 +33,8 @@
     "typescript": "^5.0.0"
   },
   "dependencies": {
-    "@tanstack/react-query": "^5.83.0"
+    "@tanstack/query-async-storage-persister": "^5.83.1",
+    "@tanstack/react-query": "^5.83.0",
+    "@tanstack/react-query-persist-client": "^5.84.1"
   }
 }

--- a/packages/gatekeeper/src/components/Gate.tsx
+++ b/packages/gatekeeper/src/components/Gate.tsx
@@ -83,9 +83,9 @@ export interface GateProps {
  */
 export const Gate: React.FC<GateProps> = React.memo(({ flag, children, onError }) => {
   const flagArray = useMemo(() => [flag], [flag]);
-  const { flags, isLoading } = useFeatureFlags({ flags: flagArray });
+  const { flags } = useFeatureFlags({ flags: flagArray });
 
-  if (isLoading || !flags[flag]) {
+  if (!flags[flag]) {
     return null;
   }
 

--- a/packages/gatekeeper/src/components/Toggle.tsx
+++ b/packages/gatekeeper/src/components/Toggle.tsx
@@ -57,11 +57,7 @@ export const Toggle: React.FC<ToggleProps> = React.memo(({
   onError 
 }) => {
   const flagArray = useMemo(() => [flag], [flag]);
-  const { flags, isLoading } = useFeatureFlags({ flags: flagArray });
-
-  if (isLoading) {
-    return null;
-  }
+  const { flags } = useFeatureFlags({ flags: flagArray });
 
   if (flags[flag]) {
     return (

--- a/packages/gatekeeper/src/hooks/useFlagSubscription.ts
+++ b/packages/gatekeeper/src/hooks/useFlagSubscription.ts
@@ -47,6 +47,7 @@ export const useFlagSubscription = (subscribedFlags: string[]) => {
     isLoading,
     isError,
     error,
+    isPending,
   } = useQuery({
     queryKey: ['flags', userId],
     queryFn: () => fetchFlags(apiUrl, userId),
@@ -84,7 +85,7 @@ export const useFlagSubscription = (subscribedFlags: string[]) => {
 
   return {
     flags: relevantFlags,
-    isLoading,
+    isLoading: isPending && !allFlags,
     isError,
     error,
   };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -75,9 +75,15 @@ importers:
 
   packages/gatekeeper:
     dependencies:
+      '@tanstack/query-async-storage-persister':
+        specifier: ^5.83.1
+        version: 5.83.1
       '@tanstack/react-query':
         specifier: ^5.83.0
         version: 5.83.0(react@19.1.0)
+      '@tanstack/react-query-persist-client':
+        specifier: ^5.84.1
+        version: 5.84.1(@tanstack/react-query@5.83.0(react@19.1.0))(react@19.1.0)
       react:
         specifier: '>=16.8.0'
         version: 19.1.0
@@ -803,8 +809,23 @@ packages:
   '@tailwindcss/postcss@4.1.11':
     resolution: {integrity: sha512-q/EAIIpF6WpLhKEuQSEVMZNMIY8KhWoAemZ9eylNAih9jxMGAYPPWBn3I9QL/2jZ+e7OEz/tZkX5HwbBR4HohA==}
 
+  '@tanstack/query-async-storage-persister@5.83.1':
+    resolution: {integrity: sha512-P3QzGBn9/nxaCst1hNYDQbbJDKFxTBsGTMjf0YtsKs7sSeNp7wVgUKjOVJpbvhdpFKHqTDYOdjOf2Qeb4bJ9tQ==}
+
   '@tanstack/query-core@5.83.0':
     resolution: {integrity: sha512-0M8dA+amXUkyz5cVUm/B+zSk3xkQAcuXuz5/Q/LveT4ots2rBpPTZOzd7yJa2Utsf8D2Upl5KyjhHRY+9lB/XA==}
+
+  '@tanstack/query-core@5.83.1':
+    resolution: {integrity: sha512-OG69LQgT7jSp+5pPuCfzltq/+7l2xoweggjme9vlbCPa/d7D7zaqv5vN/S82SzSYZ4EDLTxNO1PWrv49RAS64Q==}
+
+  '@tanstack/query-persist-client-core@5.83.1':
+    resolution: {integrity: sha512-GPWt1tj8kmo3LA1WPpSmJA3JGCdQfaggb1LheFEfr3RuwbTchWd09xD/fZ40m9ai0pJupvyguLiWF8On8sQWPw==}
+
+  '@tanstack/react-query-persist-client@5.84.1':
+    resolution: {integrity: sha512-Qpn2kg7eI+dI4AHeXmI0FYn1JVwluSESA3iJ+KJv9zZiluPhiFmzFT++j9QYwu/LHUwp4PmjqSPHkuBLiYkTRQ==}
+    peerDependencies:
+      '@tanstack/react-query': ^5.84.1
+      react: ^18 || ^19
 
   '@tanstack/react-query@5.83.0':
     resolution: {integrity: sha512-/XGYhZ3foc5H0VM2jLSD/NyBRIOK4q9kfeml4+0x2DlL6xVuAcVEW+hTlTapAmejObg0i3eNqhkr2dT+eciwoQ==}
@@ -2200,7 +2221,23 @@ snapshots:
       postcss: 8.5.6
       tailwindcss: 4.1.11
 
+  '@tanstack/query-async-storage-persister@5.83.1':
+    dependencies:
+      '@tanstack/query-persist-client-core': 5.83.1
+
   '@tanstack/query-core@5.83.0': {}
+
+  '@tanstack/query-core@5.83.1': {}
+
+  '@tanstack/query-persist-client-core@5.83.1':
+    dependencies:
+      '@tanstack/query-core': 5.83.1
+
+  '@tanstack/react-query-persist-client@5.84.1(@tanstack/react-query@5.83.0(react@19.1.0))(react@19.1.0)':
+    dependencies:
+      '@tanstack/query-persist-client-core': 5.83.1
+      '@tanstack/react-query': 5.83.0(react@19.1.0)
+      react: 19.1.0
 
   '@tanstack/react-query@5.83.0(react@19.1.0)':
     dependencies:


### PR DESCRIPTION
### TL;DR

Implemented localStorage persistence for feature flags using TanStack Query persistence utilities, eliminating all loading states to provide instant UI rendering on subsequent visits.

### What changed?

- Added TanStack Query persistence dependencies (`@tanstack/react-query-persist-client` and `@tanstack/query-async-storage-persister`)
- Replaced `QueryClientProvider` with `PersistQueryClientProvider` in FeatureFlagProvider
- Configured localStorage persister with 24-hour cache duration and 1-second throttling
- Modified `useFlagSubscription` to only show loading when no cached data exists
- Removed `isLoading` checks from Gate and Toggle components for instant rendering
- Eliminated mounted state tracking and loading screens from demo app

### How to test?

1. Run the demo app and toggle feature flags on/off using the switch
2. Refresh the page - flags should render instantly without loading states
3. Check browser DevTools Application tab for `FEATURE_FLAGS_CACHE` in localStorage
4. Verify table columns show/hide immediately based on cached flag state
5. Test with network disabled to confirm offline functionality with cached flags

### Why make this change?

This eliminates loading flickers and provides a seamless user experience by leveraging browser localStorage to cache feature flag states. Users now see instant UI updates on subsequent visits while the system silently syncs with the server in the background, maintaining data freshness without impacting perceived performance.